### PR TITLE
Add links to TeX Gyre Schola live preview

### DIFF
--- a/families/TeX_Gyre/Schola/2.005/README.md
+++ b/families/TeX_Gyre/Schola/2.005/README.md
@@ -1,10 +1,11 @@
-# Using TeX Gyre Schola
+# TeX Gyre Schola 2.005
 
 This directory contains [`style.css`](style.css) for using TeX Gyre Schola 2.005 along
 with HTML files to preview the font family:
 
-* [`preview.html`](preview.html)
+* [`preview.html`](preview.html) ([rendered][rendered-preview])
 * [`preview-with-math.html`](preview-with-math.html)
+  ([rendered][rendered-preview-with-math])
 
 ## Fonts
 
@@ -16,5 +17,7 @@ The font files themselves are in the
 
 See [TeX Gyre license][tg-license] for more information.
 
-[tg-license]: ../../README.md#license
+[rendered-preview]: https://mbrukman.github.io/fonts/families/TeX_Gyre/Schola/2.005/preview.html
+[rendered-preview-with-math]: https://mbrukman.github.io/fonts/families/TeX_Gyre/Schola/2.005/preview-with-math.html
 [tgs-2.005]: ../../../../third_party/TeX_Gyre/Schola/2.005
+[tg-license]: ../../README.md#license

--- a/families/TeX_Gyre/Schola/2.005/preview-with-math.html
+++ b/families/TeX_Gyre/Schola/2.005/preview-with-math.html
@@ -21,7 +21,7 @@
     <style>
       body {
         font-family: "TeX Gyre Schola";
-        font-size: 10pt;
+        font-size: 14pt;
         padding-left: 10%;
         padding-right: 10%;
       }


### PR DESCRIPTION
GitHub now automatically publishes the `main` branch of this repo on
https://mbrukman.github.io/fonts/ for each commit, so we can reference the live
rendered HTML files there, which reference the font files in our `third_party`
directory.

Minor changes and cleanups:

* increased font size in `preview-with-math.html` to 14pt
* fix title in TeX Gyre Schola 2.005 to drop the leading word "Using" for
  consistency with other similar directories
* reodered link references in Markdown to follow usage order